### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 requires = ["jupyterlab>=3.0.0"]
 
 dev_requires = requires + [
-    "black>=20.",
+    "black>=20.0",
     "bump2version>=1.0.0",
     "flake8>=3.7.8",
     "flake8-black>=0.2.1",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 requires = ["jupyterlab>=3.0.0"]
 
 dev_requires = requires + [
-    "black>=20.0",
+    "black>=20.0*",
     "bump2version>=1.0.0",
     "flake8>=3.7.8",
     "flake8-black>=0.2.1",


### PR DESCRIPTION
Fixed InvalidVersionSpec thrown by conda:

This is thrown when using `conda` with `conda config --set pip_interop_enabled True`

```
WARNING conda.core.index:push_record(267): Skipping pypi/pypi::jupyterlab-templates-0.3.1-pypi_0 due to InvalidSpec: 20.

Solving environment: failed with repodata from current_repodata.json, will retry with next repodata source.

InvalidVersionSpec: Invalid version '20.': empty version component
```